### PR TITLE
[Style] Add signifier to indicate photo clickable

### DIFF
--- a/app/src/main/res/drawable/ic_photo_library_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_photo_library_white_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M22,16L22,4c0,-1.1 -0.9,-2 -2,-2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2zM11,12l2.03,2.71L16,11l4,5L8,16l3,-4zM2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6L2,6z"/>
+</vector>

--- a/app/src/main/res/layout/confirm_post.xml
+++ b/app/src/main/res/layout/confirm_post.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
     <LinearLayout
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_width="match_parent"
         android:orientation="vertical" >
 
@@ -14,14 +14,21 @@
             xmlns:app="http://schemas.android.com/apk/res-auto"
             app:cardCornerRadius="16dp"
             android:layout_margin="30dp"
-            android:layout_gravity="center">
+            android:layout_gravity="center" >
             <ImageView
                 android:id="@+id/confirm_cover_image"
                 android:layout_width="320dp"
                 android:layout_height="320dp"
                 android:scaleType="centerCrop" />
+            <ImageView
+                android:id="@+id/photo_library_icon"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_gravity="top|end"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:src="@drawable/ic_photo_library_white_24dp" />
         </androidx.cardview.widget.CardView>
-
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Goal: to solve the ignorance of the function of ‘see all selected photos’
Solution: Add photo collection icon on cover photo on the post confirmation page to indicate photo clickable.

![Screenshot 2023-11-15 at 9 04 33 PM](https://github.com/wutonytt/TravelTales/assets/46513807/4d2ce463-c203-48c1-929a-4187c8f50c05)
